### PR TITLE
Implement attribute-based finding

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * Helper functions for handling strings.
@@ -14,14 +15,15 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
-     *   <br>examples:<pre>
+     * Ignores case, but a full word match is required.
+     * <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
      *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
      *       </pre>
+     *
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param word     cannot be null, cannot be empty, must be a single word
      */
     public static boolean containsWordIgnoreCase(String sentence, String word) {
         requireNonNull(sentence);
@@ -39,6 +41,28 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code search}.
+     * Ignores case, and matches based on string. No full word match is required.
+     * <br>examples:<pre>
+     *       containsStringIgnoreCase("ABc def", "abc") == true
+     *       containsStringIgnoreCase("ABc def", "AB") == true // not a full word match
+     *       containsStringIgnoreCase("ABc def", "xyz") == false
+     *       </pre>
+     *
+     * @param sentence cannot be null
+     * @param search   cannot be null, cannot be empty
+     */
+    public static boolean containsStringIgnoreCase(String sentence, String search) {
+        requireNonNull(sentence);
+        requireNonNull(search);
+
+        String preppedSearch = search.trim();
+        checkArgument(!preppedSearch.isEmpty(), "Search parameter cannot be empty");
+
+        return Pattern.compile(Pattern.quote(preppedSearch), Pattern.CASE_INSENSITIVE).matcher(sentence).find();
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {
@@ -53,6 +77,7 @@ public class StringUtil {
      * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     *
      * @throws NullPointerException if {@code s} is null.
      */
     public static boolean isNonZeroUnsignedInteger(String s) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.eatery.NameContainsKeywordsPredicate;
+import seedu.address.model.eatery.EateryAttributesContainsKeywordsPredicate;
 
 /**
  * Finds and lists all eateries in address book whose name contains any of the argument keywords.
@@ -14,14 +18,18 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " wanton mee";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all eateries whose attributes contain all of "
+            + "the specified constraints (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: "
+            + "[" + PREFIX_NAME + " NAME] "
+            + "[" + PREFIX_ADDRESS + " ADDRESS] "
+            + "[" + PREFIX_CATEGORY + " CATEGORY] "
+            + "[" + PREFIX_TAG + " TAG]...\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_CATEGORY + " chinese " + PREFIX_TAG + " delicious";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final EateryAttributesContainsKeywordsPredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(EateryAttributesContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,18 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.eatery.NameContainsKeywordsPredicate;
+import seedu.address.model.eatery.EateryAttributesContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -16,18 +22,40 @@ public class FindCommandParser implements Parser<FindCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_CATEGORY, PREFIX_TAG);
+
+        List<String> nameKeywords = new ArrayList<>();
+        List<String> addressKeywords = new ArrayList<>();
+        List<String> categoryKeywords = new ArrayList<>();
+        List<String> tagKeywords = new ArrayList<>();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            addressKeywords = argMultimap.getAllValues(PREFIX_ADDRESS);
+        }
+        if (argMultimap.getValue(PREFIX_CATEGORY).isPresent()) {
+            categoryKeywords = argMultimap.getAllValues(PREFIX_CATEGORY);
+        }
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+        }
+
+        if (nameKeywords.isEmpty() && addressKeywords.isEmpty()
+                && categoryKeywords.isEmpty() && tagKeywords.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(new EateryAttributesContainsKeywordsPredicate(
+                nameKeywords, addressKeywords, categoryKeywords, tagKeywords));
     }
 
 }

--- a/src/main/java/seedu/address/model/eatery/EateryAttributesContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/eatery/EateryAttributesContainsKeywordsPredicate.java
@@ -34,17 +34,17 @@ public class EateryAttributesContainsKeywordsPredicate implements Predicate<Eate
 
     @Override
     public boolean test(Eatery eatery) {
-        boolean nameMatch = nameKeywords.isEmpty() || nameKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getName().fullName, keyword));
-        boolean addressMatch = addressKeywords.isEmpty() || addressKeywords.stream()
+        boolean nameMatch = !nameKeywords.isEmpty() && nameKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(eatery.getName().fullName, keyword));
+        boolean addressMatch = !addressKeywords.isEmpty() && addressKeywords.stream()
                 .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(eatery.getAddress().value, keyword));
-        boolean categoryMatch = categoryKeywords.isEmpty() || categoryKeywords.stream()
+        boolean categoryMatch = !categoryKeywords.isEmpty() && categoryKeywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getCategory().getName(), keyword));
-        boolean tagMatch = tagKeywords.isEmpty() || tagKeywords.stream()
+        boolean tagMatch = !tagKeywords.isEmpty() && tagKeywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         eatery.getTags().stream().map(Tag::getName).collect(Collectors.joining(" ")), keyword));
 
-        return nameMatch && addressMatch && categoryMatch && tagMatch;
+        return nameMatch || addressMatch || categoryMatch || tagMatch;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/eatery/EateryAttributesContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/eatery/EateryAttributesContainsKeywordsPredicate.java
@@ -1,0 +1,59 @@
+package seedu.address.model.eatery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Eatery}'s attributes ({@code Name}, {@code Address}, {@code Category}, {@code Tags})
+ * matches any of the keywords given.
+ */
+public class EateryAttributesContainsKeywordsPredicate implements Predicate<Eatery> {
+    private final List<String> nameKeywords;
+    private final List<String> addressKeywords;
+    private final List<String> categoryKeywords;
+    private final List<String> tagKeywords;
+
+    public EateryAttributesContainsKeywordsPredicate(List<String> nameKeywords, List<String> addressKeywords,
+                                                     List<String> categoryKeywords, List<String> tagKeywords) {
+        this.nameKeywords = nameKeywords;
+        this.addressKeywords = addressKeywords;
+        this.categoryKeywords = categoryKeywords;
+        this.tagKeywords = tagKeywords;
+    }
+
+    public EateryAttributesContainsKeywordsPredicate(List<String> nameKeywords) {
+        this.nameKeywords = nameKeywords;
+        this.addressKeywords = new ArrayList<>();
+        this.categoryKeywords = new ArrayList<>();
+        this.tagKeywords = new ArrayList<>();
+    }
+
+    @Override
+    public boolean test(Eatery eatery) {
+        boolean nameMatch = nameKeywords.isEmpty() || nameKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getName().fullName, keyword));
+        boolean addressMatch = addressKeywords.isEmpty() || addressKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(eatery.getAddress().value, keyword));
+        boolean categoryMatch = categoryKeywords.isEmpty() || categoryKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(eatery.getCategory().getName(), keyword));
+        boolean tagMatch = tagKeywords.isEmpty() || tagKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
+                        eatery.getTags().stream().map(Tag::getName).collect(Collectors.joining(" ")), keyword));
+
+        return nameMatch && addressMatch && categoryMatch && tagMatch;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EateryAttributesContainsKeywordsPredicate // instanceof handles nulls
+                && nameKeywords.equals(((EateryAttributesContainsKeywordsPredicate) other).nameKeywords)
+                && addressKeywords.equals(((EateryAttributesContainsKeywordsPredicate) other).addressKeywords)
+                && categoryKeywords.equals(((EateryAttributesContainsKeywordsPredicate) other).categoryKeywords)
+                && tagKeywords.equals(((EateryAttributesContainsKeywordsPredicate) other).tagKeywords));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -56,13 +56,13 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_allEateriesFound() {
-        String expectedMessage = String.format(MESSAGE_EATERIES_LISTED_OVERVIEW, 7);
+    public void execute_zeroKeywords_noEateryFound() {
+        String expectedMessage = String.format(MESSAGE_EATERIES_LISTED_OVERVIEW, 0);
         EateryAttributesContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredEateryList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(expectedModel.getFilteredEateryList(), model.getFilteredEateryList());
+        assertEquals(Collections.emptyList(), model.getFilteredEateryList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.eatery.NameContainsKeywordsPredicate;
+import seedu.address.model.eatery.EateryAttributesContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -30,10 +30,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        EateryAttributesContainsKeywordsPredicate firstPredicate =
+                new EateryAttributesContainsKeywordsPredicate(Collections.singletonList("first"));
+        EateryAttributesContainsKeywordsPredicate secondPredicate =
+                new EateryAttributesContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -56,19 +56,19 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noEateryFound() {
-        String expectedMessage = String.format(MESSAGE_EATERIES_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+    public void execute_zeroKeywords_allEateriesFound() {
+        String expectedMessage = String.format(MESSAGE_EATERIES_LISTED_OVERVIEW, 7);
+        EateryAttributesContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredEateryList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredEateryList());
+        assertEquals(expectedModel.getFilteredEateryList(), model.getFilteredEateryList());
     }
 
     @Test
     public void execute_multipleKeywords_multipleEateriesFound() {
         String expectedMessage = String.format(MESSAGE_EATERIES_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("McDonald Kentucky Texas");
+        EateryAttributesContainsKeywordsPredicate predicate = preparePredicate("McDonald Kentucky Texas");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredEateryList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -76,9 +76,9 @@ public class FindCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code EateryAttributesContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private EateryAttributesContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new EateryAttributesContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,6 +13,8 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EATERY;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -96,10 +98,11 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        String keywords = "foo bar baz";
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + " " + keywords, true);
-        assertEquals(new FindCommand(new EateryAttributesContainsKeywordsPredicate(Arrays.asList(keywords))), command);
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " "
+                + keywords.stream().map(k -> String.format("%s %s", PREFIX_NAME, k))
+                .collect(Collectors.joining(" ")), true);
+        assertEquals(new FindCommand(new EateryAttributesContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,12 +8,11 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_EATBOOK;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_EATBOOK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_EATBOOK;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_EATBOOK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EATERY;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import seedu.address.logic.commands.SaveTodoCommand;
 import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.eatery.Eatery;
-import seedu.address.model.eatery.NameContainsKeywordsPredicate;
+import seedu.address.model.eatery.EateryAttributesContainsKeywordsPredicate;
 import seedu.address.model.feed.Feed;
 import seedu.address.testutil.EateryBuilder;
 import seedu.address.testutil.EateryUtil;
@@ -82,7 +81,8 @@ public class AddressBookParserTest {
         assertEquals(new CloseCommand(INDEX_FIRST_EATERY), command);
     }
 
-    @Test public void parseCommand_reopen() throws Exception {
+    @Test
+    public void parseCommand_reopen() throws Exception {
         ReopenCommand command = (ReopenCommand) parser.parseCommand(
                 ReopenCommand.COMMAND_WORD + " " + INDEX_FIRST_EATERY.getOneBased(), true);
         assertEquals(new ReopenCommand(INDEX_FIRST_EATERY), command);
@@ -96,10 +96,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        String keywords = "foo bar baz";
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")), true);
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + " " + keywords, true);
+        assertEquals(new FindCommand(new EateryAttributesContainsKeywordsPredicate(Arrays.asList(keywords))), command);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_saveTodo() throws Exception {
         SaveTodoCommand command = (SaveTodoCommand) parser.parseCommand(
-            SaveTodoCommand.COMMAND_WORD + " " + INDEX_FIRST_EATERY.getOneBased(), false);
+                SaveTodoCommand.COMMAND_WORD + " " + INDEX_FIRST_EATERY.getOneBased(), false);
         assertEquals(new SaveTodoCommand(INDEX_FIRST_EATERY), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,7 +10,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.eatery.NameContainsKeywordsPredicate;
+import seedu.address.model.eatery.EateryAttributesContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -24,11 +25,11 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new EateryAttributesContainsKeywordsPredicate(Arrays.asList("Alice Bob")));
+        assertParseSuccess(parser, " " + PREFIX_NAME + " Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "\n \t Alice Bob  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,11 +1,22 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_NO_PREFIX_KFC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_NO_PREFIX_MAC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CATEGORY_NO_PREFIX;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_NO_PREFIX_KFC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_NO_PREFIX_MAC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_NO_PREFIX_CHEAP;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_NO_PREFIX_NICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,11 +36,33 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new EateryAttributesContainsKeywordsPredicate(Arrays.asList("Alice Bob")));
-        assertParseSuccess(parser, " " + PREFIX_NAME + " Alice Bob", expectedFindCommand);
+                new FindCommand(new EateryAttributesContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        assertParseSuccess(parser, " " + PREFIX_NAME + " Alice " + PREFIX_NAME + " Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " " + PREFIX_NAME + "\n \t Alice Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser,
+                " " + PREFIX_NAME + "\n \t Alice \t  " + PREFIX_NAME + " Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validMultiArgs_returnFindCommand() {
+        List<String> nameKeywords = Arrays.asList(VALID_NAME_NO_PREFIX_MAC, VALID_NAME_NO_PREFIX_KFC);
+        List<String> addressKeywords = Arrays.asList(VALID_ADDRESS_NO_PREFIX_MAC, VALID_ADDRESS_NO_PREFIX_KFC);
+        List<String> categoryKeywords = Arrays.asList(VALID_CATEGORY_NO_PREFIX);
+        List<String> tagKeywords = Arrays.asList(VALID_TAG_NO_PREFIX_CHEAP, VALID_TAG_NO_PREFIX_NICE);
+
+        FindCommand expectedFindCommand = new FindCommand(new EateryAttributesContainsKeywordsPredicate(
+                nameKeywords, addressKeywords, categoryKeywords, tagKeywords));
+
+        assertParseSuccess(parser,
+                " " + PREFIX_NAME + " " + VALID_NAME_NO_PREFIX_MAC
+                        + " " + PREFIX_NAME + " " + VALID_NAME_NO_PREFIX_KFC
+                        + " " + PREFIX_ADDRESS + " " + VALID_ADDRESS_NO_PREFIX_MAC
+                        + " " + PREFIX_ADDRESS + " " + VALID_ADDRESS_NO_PREFIX_KFC
+                        + " " + PREFIX_CATEGORY + " " + VALID_CATEGORY_NO_PREFIX
+                        + " " + PREFIX_TAG + " " + VALID_TAG_NO_PREFIX_CHEAP
+                        + " " + PREFIX_TAG + " " + VALID_TAG_NO_PREFIX_NICE,
+                expectedFindCommand);
     }
 
 }


### PR DESCRIPTION
Closes #113 

Implements finding based on multiple Eatery attributes (`name`, `address`, `category`, `tags`) through the introduction of a new `EateryAttributesContainsKeywordsPredicate`. 